### PR TITLE
Make the library phpunit 10 compatible

### DIFF
--- a/.github/workflows/code_analysis.yaml
+++ b/.github/workflows/code_analysis.yaml
@@ -4,7 +4,7 @@ on:
     pull_request: null
     push:
         branches:
-            - main
+            - master
 
 jobs:
     code_analysis:

--- a/.github/workflows/code_analysis.yaml
+++ b/.github/workflows/code_analysis.yaml
@@ -11,6 +11,10 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
+                php:
+                    - "8.1"
+                    - "8.2"
+                    - "8.3"
                 actions:
                     -
                         name: "PHPStan"
@@ -20,7 +24,7 @@ jobs:
                         name: "PHPUnit"
                         run: vendor/bin/phpunit
 
-        name: ${{ matrix.actions.name }}
+        name: PHP${{ matrix.php }}:${{ matrix.actions.name }} 
         runs-on: ubuntu-latest
 
         steps:
@@ -29,7 +33,7 @@ jobs:
             # see https://github.com/shivammathur/setup-php
             -   uses: shivammathur/setup-php@v2
                 with:
-                    php-version: 7.4
+                    php-version: ${{ matrix.php }})
                     coverage: none
 
             # composer install cache - https://github.com/ramsey/composer-install

--- a/.github/workflows/code_analysis.yaml
+++ b/.github/workflows/code_analysis.yaml
@@ -29,7 +29,7 @@ jobs:
             # see https://github.com/shivammathur/setup-php
             -   uses: shivammathur/setup-php@v2
                 with:
-                    php-version: 7.4
+                    php-version: 8.1
                     coverage: none
 
             # composer install cache - https://github.com/ramsey/composer-install

--- a/.github/workflows/code_analysis.yaml
+++ b/.github/workflows/code_analysis.yaml
@@ -33,6 +33,6 @@ jobs:
                     coverage: none
 
             # composer install cache - https://github.com/ramsey/composer-install
-            -   uses: "ramsey/composer-install@v1"
+            -   uses: "ramsey/composer-install@v2"
 
             -   run: ${{ matrix.actions.run }}

--- a/.github/workflows/code_analysis.yaml
+++ b/.github/workflows/code_analysis.yaml
@@ -24,7 +24,7 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-            -   uses: actions/checkout@v2
+            -   uses: actions/checkout@v4
 
             # see https://github.com/shivammathur/setup-php
             -   uses: shivammathur/setup-php@v2

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 composer.lock
 vendor/
 .phpunit.result.cache
+.phpunit.cache

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,11 @@
     "description": "Library for asserting things that happen asynchronously with PHPUnit",
     "license": "MIT",
     "type": "library",
-    "keywords": ["PHPUnit", "asynchronicity", "assertion"],
+    "keywords": [
+        "PHPUnit",
+        "asynchronicity",
+        "assertion"
+    ],
     "authors": [
         {
             "name": "Matthias Noback",
@@ -22,10 +26,11 @@
         }
     },
     "require": {
-        "php": "^7.3 || ^8.0"
+        "php": "^8.1"
     },
     "require-dev": {
-        "phpstan/phpstan": "^0.9.2",
-        "phpunit/phpunit": "^9.0"
+        "phpstan/phpstan": "^1.10",
+        "phpunit/phpunit": "^10.0",
+        "ext-pcntl": "*"
     }
 }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3,28 +3,4 @@ parameters:
     paths:
         - src
         - tests
-    ignoreErrors:
-        -
-            message: '#Method Asynchronicity\\PHPUnit\\Eventually::evaluate\(\) has parameter \$probe with no type specified\.#'
-            count: 1
-            path: 'src/Asynchronicity/PHPUnit/Eventually.php'
-
-        -
-            message: '#Method Asynchronicity\\PHPUnit\\Eventually::failureDescription\(\) has parameter \$other with no type specified\.#'
-            count: 1
-            path: 'src/Asynchronicity/PHPUnit/Eventually.php'
-
-        -
-            message: '#Dead catch - Asynchronicity\\Polling\\Interrupted is never thrown in the try block\.#'
-            count: 1
-            path: 'tests/Asynchronicity/PHPUnit/EventuallyTest.php'
-
-        -
-            message: '#Call to an undefined method Asynchronicity\\Polling\\Clock::expects\(\)\.#'
-            count: 4
-            path: 'tests/Asynchronicity/Polling/PollerTest.php'
-
-        -
-            message: '#Method Asynchronicity\\Polling\\TimeoutTest::clockReturnsMicrotimes\(\) has parameter \$microtimes with no value type specified in iterable type array\.#'
-            count: 1
-            path: 'tests/Asynchronicity/Polling/TimeoutTest.php'
+    ignoreErrors: []

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3,3 +3,28 @@ parameters:
     paths:
         - src
         - tests
+    ignoreErrors:
+        -
+            message: '#Method Asynchronicity\\PHPUnit\\Eventually::evaluate\(\) has parameter \$probe with no type specified\.#'
+            count: 1
+            path: 'src/Asynchronicity/PHPUnit/Eventually.php'
+
+        -
+            message: '#Method Asynchronicity\\PHPUnit\\Eventually::failureDescription\(\) has parameter \$other with no type specified\.#'
+            count: 1
+            path: 'src/Asynchronicity/PHPUnit/Eventually.php'
+
+        -
+            message: '#Dead catch - Asynchronicity\\Polling\\Interrupted is never thrown in the try block\.#'
+            count: 1
+            path: 'tests/Asynchronicity/PHPUnit/EventuallyTest.php'
+
+        -
+            message: '#Call to an undefined method Asynchronicity\\Polling\\Clock::expects\(\)\.#'
+            count: 4
+            path: 'tests/Asynchronicity/Polling/PollerTest.php'
+
+        -
+            message: '#Method Asynchronicity\\Polling\\TimeoutTest::clockReturnsMicrotimes\(\) has parameter \$microtimes with no value type specified in iterable type array\.#'
+            count: 1
+            path: 'tests/Asynchronicity/Polling/TimeoutTest.php'

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,17 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="./vendor/autoload.php" colors="true">
-    <testsuites>
-        <testsuite name="Tests">
-            <directory suffix="Test.php">./tests</directory>
-        </testsuite>
-    </testsuites>
-    <filter>
-        <whitelist>
-            <directory>./</directory>
-            <exclude>
-                <directory>./tests</directory>
-                <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="./vendor/autoload.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.4/phpunit.xsd" cacheDirectory=".phpunit.cache">
+  <coverage/>
+  <testsuites>
+    <testsuite name="Tests">
+      <directory suffix="Test.php">./tests</directory>
+    </testsuite>
+  </testsuites>
+  <source>
+    <include>
+      <directory>./</directory>
+    </include>
+    <exclude>
+      <directory>./tests</directory>
+      <directory>./vendor</directory>
+    </exclude>
+  </source>
 </phpunit>

--- a/src/Asynchronicity/PHPUnit/Eventually.php
+++ b/src/Asynchronicity/PHPUnit/Eventually.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Asynchronicity\PHPUnit;
 
+use Asynchronicity\Polling\IncorrectUsage;
 use Asynchronicity\Polling\Interrupted;
 use Asynchronicity\Polling\Poller;
 use Asynchronicity\Polling\SystemClock;
@@ -20,8 +21,15 @@ final class Eventually extends Constraint
         $this->waitMilliseconds = $waitMilliseconds;
     }
 
-    public function evaluate($probe, string $description = '', bool $returnResult = false): ?bool
+    /**
+     * @throws Interrupted
+     */
+    public function evaluate(mixed $probe, string $description = '', bool $returnResult = false): ?bool
     {
+        if (!is_callable($probe)) {
+            throw new IncorrectUsage();
+        }
+
         try {
             $poller = new Poller();
             $poller->poll(
@@ -39,7 +47,7 @@ final class Eventually extends Constraint
         return true;
     }
 
-    protected function failureDescription($other): string
+    protected function failureDescription(mixed $other): string
     {
         return 'the given probe was satisfied within the provided timeout';
     }

--- a/src/Asynchronicity/PHPUnit/Eventually.php
+++ b/src/Asynchronicity/PHPUnit/Eventually.php
@@ -46,6 +46,6 @@ final class Eventually extends Constraint
 
     public function toString(): string
     {
-        throw new \BadMethodCallException('Not implemented');
+        return 'Eventually';
     }
 }

--- a/src/Asynchronicity/PHPUnit/Eventually.php
+++ b/src/Asynchronicity/PHPUnit/Eventually.php
@@ -11,8 +11,8 @@ use PHPUnit\Framework\Constraint\Constraint;
 
 final class Eventually extends Constraint
 {
-    private $timeoutMilliseconds;
-    private $waitMilliseconds;
+    private int $timeoutMilliseconds;
+    private int $waitMilliseconds;
 
     public function __construct(int $timeoutMilliseconds = 5000, int $waitMilliseconds = 500)
     {

--- a/tests/Asynchronicity/PHPUnit/EventuallyTest.php
+++ b/tests/Asynchronicity/PHPUnit/EventuallyTest.php
@@ -10,10 +10,7 @@ use PHPUnit\Framework\TestCase;
 
 final class EventuallyTest extends TestCase
 {
-    /**
-     * @var Eventually
-     */
-    private $constraint;
+    private Eventually $constraint;
 
     /**
      * @var callable
@@ -99,6 +96,17 @@ final class EventuallyTest extends TestCase
         $this->assertTrue($constraint->evaluate(function (): void {
             return;
         }));
+    }
+
+    /**
+     * @test
+     */
+    public function it_throws_an_exception_if_the_probe_is_not_callable(): void
+    {
+        $constraint = new Eventually();
+
+        $this->expectException(IncorrectUsage::class);
+        $constraint->evaluate('foobar');
     }
 
     /**

--- a/tests/Asynchronicity/PHPUnit/EventuallyTest.php
+++ b/tests/Asynchronicity/PHPUnit/EventuallyTest.php
@@ -101,6 +101,16 @@ final class EventuallyTest extends TestCase
         }));
     }
 
+    /**
+     * @test
+     */
+    public function it_is_stringable(): void
+    {
+        $constraint = new Eventually();
+
+        $this->assertSame('Eventually', $constraint->toString());
+    }
+
     private function probeAlwaysFails(): void
     {
         $this->probe = function (): void {

--- a/tests/Asynchronicity/PHPUnit/FileHasBeenCreated.php
+++ b/tests/Asynchronicity/PHPUnit/FileHasBeenCreated.php
@@ -7,7 +7,7 @@ use PHPUnit\Framework\Assert;
 
 final class FileHasBeenCreated
 {
-    private $path;
+    private string $path;
 
     public function __construct(string $path)
     {

--- a/tests/Asynchronicity/PHPUnit/IntegrationTest.php
+++ b/tests/Asynchronicity/PHPUnit/IntegrationTest.php
@@ -15,14 +15,14 @@ final class IntegrationTest extends TestCase
     public function it_waits_until_a_child_process_does_something(): void
     {
         if (!\extension_loaded('pcntl')) {
-            $this->markTestSkipped('Requires PCNTL extension');
+            self::markTestSkipped('Requires PCNTL extension');
         }
 
         $timeoutMilliseconds = 2000;
         $waitMilliseconds = 1000;
 
         $file = sys_get_temp_dir().'/'.uniqid('phpunit-asynchronicity', true);
-        $this->assertFileNotExists($file);
+        self::assertFileDoesNotExist($file);
 
         $pid = pcntl_fork();
         if ($pid === -1) {

--- a/tests/Asynchronicity/Polling/PollerTest.php
+++ b/tests/Asynchronicity/Polling/PollerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Asynchronicity\Polling;
 
 use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 final class PollerTest extends TestCase
@@ -21,7 +22,7 @@ final class PollerTest extends TestCase
     private $poller;
 
     /**
-     * @var Clock
+     * @var Clock&MockObject
      */
     private $clock;
 

--- a/tests/Asynchronicity/Polling/PollerTest.php
+++ b/tests/Asynchronicity/Polling/PollerTest.php
@@ -8,7 +8,7 @@ use PHPUnit\Framework\TestCase;
 
 final class PollerTest extends TestCase
 {
-    private $waitTimeInMilliseconds = 1000;
+    private int $waitTimeInMilliseconds = 1000;
 
     /**
      * @var callable

--- a/tests/Asynchronicity/Polling/TimeoutTest.php
+++ b/tests/Asynchronicity/Polling/TimeoutTest.php
@@ -88,18 +88,9 @@ final class TimeoutTest extends TestCase
 
     private function clockReturnsMicrotimes(array $microtimes): void
     {
-        static $at;
-        if ($at === null) {
-            $at = 0;
-        }
-
-        foreach ($microtimes as $microtime) {
-            $this->clock
-                ->expects($this->at($at))
-                ->method('getMicrotime')
-                ->will($this->returnValue($microtime));
-
-            $at++;
-        }
+        $this->clock
+            ->expects($this->exactly(count($microtimes)))
+            ->method('getMicrotime')
+            ->willReturnOnConsecutiveCalls(...$microtimes);
     }
 }

--- a/tests/Asynchronicity/Polling/TimeoutTest.php
+++ b/tests/Asynchronicity/Polling/TimeoutTest.php
@@ -86,6 +86,9 @@ final class TimeoutTest extends TestCase
         $this->timeout->hasTimedOut();
     }
 
+    /**
+     * @param int[] $microtimes
+     */
     private function clockReturnsMicrotimes(array $microtimes): void
     {
         $this->clock

--- a/tests/Asynchronicity/Polling/TimeoutTest.php
+++ b/tests/Asynchronicity/Polling/TimeoutTest.php
@@ -14,7 +14,7 @@ final class TimeoutTest extends TestCase
     private $timeout;
 
     /**
-     * @var MockObject & Clock
+     * @var MockObject&Clock
      */
     private $clock;
 


### PR DESCRIPTION
Since phpunit 10.4 the toString() method is called when sending out events. This causes any test to fail with the 'NotImplementedException', so it needs to be implemented now.

It would be nice if we can tag this as version 3.

Here is a little snippet of the stacktrace with the new phpunit where you can see that the event trigger is causing the toString() to be called:

```
#0 /myproject/vendor/phpunit/phpunit/src/Event/Emitter/DispatchingEmitter.php(487): Asynchronicity\PHPUnit\Eventually->toString(false)
#1 /myproject/vendor/phpunit/phpunit/src/Framework/Assert.php(1881): PHPUnit\Event\DispatchingEmitter->testAssertionSucceeded(Object(Closure), Object(Asynchronicity\PHPUnit\Eventually), '')
#2 /myproject/vendor/matthiasnoback/phpunit-asynchronicity/src/Asynchronicity/PHPUnit/Asynchronicity.php(20): PHPUnit\Framework\Assert::assertThat(Object(Closure), Object(Asynchronicity\PHPUnit\Eventually))
#3 /myproject/tests/MyTest.php(228): MyProject\MyTest::assertEventually(Object(Closure), 10000)
```